### PR TITLE
feat(SvgIcon): deprecate passing icon name as string [publish]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npmlogs
 dist
 storybook-static
 *.css.d.ts
+.air

--- a/src/components/ContentPanel/ContentPanel.tsx
+++ b/src/components/ContentPanel/ContentPanel.tsx
@@ -1,4 +1,6 @@
 import '@jetbrains/ring-ui-built/components/style.css'
+import ChevronDownIcon from '@jetbrains/icons/chevron-down'
+import ChevronRightIcon from '@jetbrains/icons/chevron-right'
 import {H2} from '@jetbrains/ring-ui-built/components/heading/heading.js'
 import LoaderInline from '@jetbrains/ring-ui-built/components/loader-inline/loader-inline.js'
 import classNames from 'classnames'
@@ -76,7 +78,7 @@ function ContentPanel({
           <SvgIcon
             className={styles.chevronIcon}
             title={expanded ? 'Collapse section' : 'Expand section'}
-            icon={expanded ? 'chevron-down' : 'chevron-right'}
+            icon={expanded ? ChevronDownIcon : ChevronRightIcon}
             onClick={() => setExpanded(!expanded)}
           />
         )}

--- a/src/components/SvgIcon/SvgIcon.tsx
+++ b/src/components/SvgIcon/SvgIcon.tsx
@@ -7,8 +7,14 @@ import {pascalCase} from 'change-case'
 import classNames from 'classnames'
 import type {SVGAttributes} from 'react'
 import {Suspense, lazy, memo} from 'react'
+import deprecate from 'util-deprecate'
 
 import styles from './SvgIcon.module.css'
+
+const warnIconNameDeprecated = deprecate(
+  () => {},
+  "SvgIcon: passing icon name as a string is deprecated. Import the icon directly (e.g. `import PencilIcon from '@jetbrains/icons/pencil'`) and pass it as the `icon` prop instead. Passing raw SVG source strings is still supported.",
+)
 
 type Props = IconAttrs & {
   icon: IconType | string
@@ -35,10 +41,18 @@ export function injectGetLocalIcon(getIcon: GetIcon) {
 }
 
 export const getGlyph = memoize((icon: IconType | string): IconType | string => {
-  if (typeof icon !== 'string' || /^<svg/.test(icon)) {
+  if (typeof icon !== 'string') {
     return icon
   }
+  if (/^<svg/.test(icon)) {
+    const InlineSvg = memo((props: SVGAttributes<SVGSVGElement>) => (
+      <IconSVG {...props} src={icon} data-svg-icon data-ignore-dark-theme-adapter />
+    ))
+    InlineSvg.displayName = 'InlineSvg'
+    return InlineSvg
+  }
 
+  warnIconNameDeprecated()
   const size = getSize(icon)
   const LazySvg = lazy(() =>
     getLocalIcon != null ? getLocalIcon(icon).catch(() => getRingIcon(icon)) : getRingIcon(icon),


### PR DESCRIPTION
## Summary

- Adds a `util-deprecate` runtime warning in `SvgIcon`/`IconButton` when the `icon` prop is a string icon-name (the dynamic `import('@jetbrains/icons/${name}.js')` path). Imported SVG-source strings and `IconType` components remain supported.
- Normalizes the SVG-source-string branch in `getGlyph` to render through `IconSVG` with `data-svg-icon` and `data-ignore-dark-theme-adapter`, matching the deprecated path's DOM. Callers migrating from string names to imported icons keep the dark-theme opt-out.
- Migrates the only internal call site (`ContentPanel` chevrons at `ContentPanel.tsx:79`) to imported `ChevronDownIcon`/`ChevronRightIcon` so the library no longer warns against itself.
- Housekeeping: ignore the `.air` directory.

## Migration

Before:
```tsx
<SvgIcon icon="chevron-down" />
```
After:
```tsx
import ChevronDownIcon from '@jetbrains/icons/chevron-down'
<SvgIcon icon={ChevronDownIcon} />
```

`IconButton` inherits the deprecation transitively via the shared `getGlyph` call — no separate wiring needed.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run build` (+ postbuild `tsc`) passes
- [ ] `npm run lint` passes
- [ ] Storybook `SvgIcon/JetBrains` story (string-name) renders correctly and logs one deprecation warning per process
- [ ] Storybook `SvgIcon/Imported` story (imported SVG) renders correctly and logs **no** warning
- [ ] `ContentPanel` expandable chevron renders identically to before, with no library-emitted warning
- [ ] Inspect rendered DOM: imported-SVG path now carries `data-svg-icon` and `data-ignore-dark-theme-adapter` on the inner `<svg>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)