### PR TITLE
chore: enforce .js extension on @jetbrains/icons imports [publish]

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,6 +71,18 @@ export default tseslint.config(
         },
       ],
       'import/no-cycle': error,
+      'no-restricted-imports': [
+        error,
+        {
+          patterns: [
+            {
+              group: ['@jetbrains/icons/*', '!@jetbrains/icons/*.js'],
+              message:
+                "Import @jetbrains/icons/* with the explicit `.js` extension (e.g. `import StarFilledIcon from '@jetbrains/icons/star-filled.js'`).",
+            },
+          ],
+        },
+      ],
       'import/no-extraneous-dependencies': [
         error,
         {

--- a/src/components/ContentPanel/ContentPanel.tsx
+++ b/src/components/ContentPanel/ContentPanel.tsx
@@ -1,6 +1,6 @@
 import '@jetbrains/ring-ui-built/components/style.css'
-import ChevronDownIcon from '@jetbrains/icons/chevron-down'
-import ChevronRightIcon from '@jetbrains/icons/chevron-right'
+import ChevronDownIcon from '@jetbrains/icons/chevron-down.js'
+import ChevronRightIcon from '@jetbrains/icons/chevron-right.js'
 import {H2} from '@jetbrains/ring-ui-built/components/heading/heading.js'
 import LoaderInline from '@jetbrains/ring-ui-built/components/loader-inline/loader-inline.js'
 import classNames from 'classnames'

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -1,4 +1,4 @@
-import StarFilledIcon from '@jetbrains/icons/star-filled'
+import StarFilledIcon from '@jetbrains/icons/star-filled.js'
 
 import type {Meta, StoryObj} from '@storybook/react-vite'
 

--- a/src/components/SvgIcon/SvgIcon.stories.tsx
+++ b/src/components/SvgIcon/SvgIcon.stories.tsx
@@ -1,4 +1,4 @@
-import StarFilledIcon from '@jetbrains/icons/star-filled'
+import StarFilledIcon from '@jetbrains/icons/star-filled.js'
 
 import type {Meta, StoryObj} from '@storybook/react-vite'
 

--- a/src/components/SvgIcon/SvgIcon.tsx
+++ b/src/components/SvgIcon/SvgIcon.tsx
@@ -13,7 +13,7 @@ import styles from './SvgIcon.module.css'
 
 const warnIconNameDeprecated = deprecate(
   () => {},
-  "SvgIcon: passing icon name as a string is deprecated. Import the icon directly (e.g. `import PencilIcon from '@jetbrains/icons/pencil'`) and pass it as the `icon` prop instead. Passing raw SVG source strings is still supported.",
+  "SvgIcon: passing icon name as a string is deprecated. Import the icon directly (e.g. `import PencilIcon from '@jetbrains/icons/pencil.js'`) and pass it as the `icon` prop instead. Passing raw SVG source strings is still supported.",
 )
 
 type Props = IconAttrs & {


### PR DESCRIPTION
## Summary

Follow-up to #260. Add an explicit `.js` extension to all static `@jetbrains/icons/*` imports and enforce the convention with a `no-restricted-imports` ESLint rule.

- Static imports updated: `ContentPanel.tsx`, `SvgIcon.stories.tsx`, `IconButton.stories.tsx`.
- Deprecation-warning example in `SvgIcon.tsx` updated to recommend the `.js` form.
- ESLint rule (`no-restricted-imports`) added to `eslint.config.mjs` with a gitignore-style pattern `['@jetbrains/icons/*', '!@jetbrains/icons/*.js']` — bans any `@jetbrains/icons/foo` import without the explicit extension.
- The existing `import/extensions` rule doesn't apply to package imports, so there is no conflict.
- Matches the extension already used in the dynamic `import(\`@jetbrains/icons/${icon}.js\`)` inside `getRingIcon` and avoids ESM/CJS resolution ambiguity.

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Manually verified: reverting any `.js` extension on a `@jetbrains/icons/*` import triggers the lint rule with the helpful message

🤖 Generated with [Claude Code](https://claude.com/claude-code)