### PR TITLE
feat(ContentPanel): add opt-in CollapsibleGroup mode [publish]

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,7 +1,12 @@
 import '@jetbrains/ring-ui-built/components/style.css'
 import type {Preview} from '@storybook/react-vite'
+import {createElement} from 'react'
 
 const preview: Preview = {
+  // Render every story with Ring UI's default font family, size, and line height.
+  decorators: [
+    Story => createElement('div', {className: 'ring-global-font'}, createElement(Story)),
+  ],
   parameters: {
     controls: {
       matchers: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "dependencies": {
         "@jetbrains/icons": "^5.8.0",
-        "@jetbrains/ring-ui-built": "^7.0.66",
+        "@jetbrains/ring-ui-built": "^7.0.116",
         "change-case": "^5.4.4",
         "classnames": "^2.5.1",
         "core-js": "^3.46.0",
@@ -37,7 +37,7 @@
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^10.0.1",
         "@jetbrains/eslint-config": "^6.0.4",
-        "@jetbrains/ring-ui": "^7.0.38",
+        "@jetbrains/ring-ui": "^7.0.116",
         "@storybook/react-vite": "^10.0.6",
         "@types/jest": "^30.0.0",
         "@types/react": "^19.1.1",
@@ -157,21 +157,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -466,14 +466,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8073,17 +8073,17 @@
       }
     },
     "node_modules/@jetbrains/ring-ui": {
-      "version": "7.0.115",
-      "resolved": "https://registry.npmjs.org/@jetbrains/ring-ui/-/ring-ui-7.0.115.tgz",
-      "integrity": "sha512-xeIi/LFrftheQm5n8uiKYpyhW6vVP9Nn2oB70WBGHra2F0Beew85PN4CawxPllJ6yAt7JeIXerI7NfLbJ4cQSQ==",
+      "version": "7.0.116",
+      "resolved": "https://registry.npmjs.org/@jetbrains/ring-ui/-/ring-ui-7.0.116.tgz",
+      "integrity": "sha512-78aDd4JccO6ZjuCognLlXIyTtn9N0JLHB02gyclGw9VgnEOr8uK5vVnFQeoFBNvwcKiBAeInYgKmcbNbSmRMcg==",
       "dev": true,
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@babel/core": "^7.29.0",
-        "@babel/preset-typescript": "^7.28.5",
+        "@babel/core": "^7.29.7",
+        "@babel/preset-typescript": "^7.29.7",
         "@jetbrains/babel-preset-jetbrains": "^2.4.0",
         "@jetbrains/icons": "^5.22.0",
         "@jetbrains/postcss-require-hover": "^0.2.0",
@@ -8100,7 +8100,7 @@
         "combokeys": "^3.0.1",
         "css-loader": "^7.1.4",
         "csstype": "^3.2.1",
-        "date-fns": "^4.3.0",
+        "date-fns": "^4.4.0",
         "dequal": "^2.0.3",
         "element-resize-detector": "^1.2.4",
         "fastdom": "^1.0.12",
@@ -8152,9 +8152,9 @@
       }
     },
     "node_modules/@jetbrains/ring-ui-built": {
-      "version": "7.0.115",
-      "resolved": "https://registry.npmjs.org/@jetbrains/ring-ui-built/-/ring-ui-built-7.0.115.tgz",
-      "integrity": "sha512-fhhKjsCTLIFO01a52yg3/qXMciVo7mvLj1mLAQFsDQmeDeGm/QbMcte9iAUJyym07NgPEAZNC23rv288VbFU7Q==",
+      "version": "7.0.116",
+      "resolved": "https://registry.npmjs.org/@jetbrains/ring-ui-built/-/ring-ui-built-7.0.116.tgz",
+      "integrity": "sha512-7iJEInGvIn4s+Iun92RtFKUNbDnxpddfi4aqtEFAkRnPfyuavJEC2c5ah6Zdjsq94K12MMWg7yZ9MlDak65mNA==",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -8164,7 +8164,7 @@
         "change-case": "^4.1.1",
         "classnames": "^2.5.1",
         "combokeys": "^3.0.1",
-        "date-fns": "^4.3.0",
+        "date-fns": "^4.4.0",
         "dequal": "^2.0.3",
         "element-resize-detector": "^1.2.4",
         "fastdom": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@jetbrains/icons": "^5.8.0",
-    "@jetbrains/ring-ui-built": "^7.0.66",
+    "@jetbrains/ring-ui-built": "^7.0.116",
     "change-case": "^5.4.4",
     "classnames": "^2.5.1",
     "core-js": "^3.46.0",
@@ -76,7 +76,7 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^10.0.1",
     "@jetbrains/eslint-config": "^6.0.4",
-    "@jetbrains/ring-ui": "^7.0.38",
+    "@jetbrains/ring-ui": "^7.0.116",
     "@storybook/react-vite": "^10.0.6",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.1.1",

--- a/src/components/ContentPanel/ContentPanel.module.css
+++ b/src/components/ContentPanel/ContentPanel.module.css
@@ -72,3 +72,7 @@
 .errorHeading {
   color: var(--ring-error-color);
 }
+
+.errorAvatar {
+  --ring-tag-background-color: var(--ring-removed-subtle-background-color);
+}

--- a/src/components/ContentPanel/ContentPanel.stories.tsx
+++ b/src/components/ContentPanel/ContentPanel.stories.tsx
@@ -1,0 +1,89 @@
+import type {Meta, StoryObj} from '@storybook/react-vite'
+import type {ReactNode} from 'react'
+import {useCallback, useState} from 'react'
+
+import ContentPanel from './ContentPanel'
+import type {ContentPanelParams} from './ContentPanel.context'
+import {ContentPanelContext} from './ContentPanel.context'
+
+// ContentPanel reads expand state from ContentPanelContext, which the host app provides in
+// production (the default context value is a no-op). Mirror that contract here: setParams
+// seeds `expanded` from `expandedByDefault` (the panel calls it once from a layout effect),
+// so stories honor expandedByDefault just like production while manual toggling still works.
+function StatefulContext({children}: {readonly children: ReactNode}) {
+  const [expanded, setExpanded] = useState(true)
+  const setParams = useCallback(({expandedByDefault}: ContentPanelParams) => {
+    setExpanded(expandedByDefault)
+  }, [])
+  return (
+    <ContentPanelContext.Provider value={{expanded, setExpanded, setParams}}>
+      {children}
+    </ContentPanelContext.Provider>
+  )
+}
+
+const kind: Meta<typeof ContentPanel> = {
+  component: ContentPanel,
+  decorators: [
+    Story => (
+      <StatefulContext>
+        <Story />
+      </StatefulContext>
+    ),
+  ],
+}
+export default kind
+
+type Story = StoryObj<typeof ContentPanel>
+
+export const Default: Story = {
+  args: {
+    panelType: 'overview',
+    heading: 'Build Problems',
+    subheading: '4 new',
+    content: <div>{'Section content.'}</div>,
+  },
+}
+
+export const AsCollapsibleGroup: Story = {
+  args: {
+    panelType: 'coverage',
+    heading: 'Code coverage',
+    content: <div>{'Section content.'}</div>,
+    collapsibleGroup: true,
+  },
+}
+
+export const AsCollapsibleGroupError: Story = {
+  args: {
+    panelType: 'failed-tests',
+    heading: '18 Failed Tests',
+    subheading: '2 new',
+    content: <div>{'Section content.'}</div>,
+    collapsibleGroup: true,
+    errorHeading: true,
+  },
+}
+
+// Exercises the expandedByDefault → setParams → context wiring: this panel starts collapsed.
+export const CollapsedByDefault: Story = {
+  args: {
+    panelType: 'collapsed',
+    heading: 'Collapsed section',
+    content: <div>{'Starts collapsed because expandedByDefault is false.'}</div>,
+    collapsibleGroup: true,
+    expandedByDefault: false,
+  },
+}
+
+// Passing props the collapsibleGroup mode ignores logs a console.warn (check the console).
+export const CollapsibleGroupWithIgnoredProps: Story = {
+  args: {
+    panelType: 'ignored-props',
+    heading: 'Open the console',
+    content: <div>{'headerSnippet / withBorder are ignored here and trigger a warning.'}</div>,
+    collapsibleGroup: true,
+    headerSnippet: <span>{'snippet'}</span>,
+    withBorder: false,
+  },
+}

--- a/src/components/ContentPanel/ContentPanel.tsx
+++ b/src/components/ContentPanel/ContentPanel.tsx
@@ -108,7 +108,7 @@ function ContentPanel(props: ContentPanelProps) {
     if (unsupportedProps !== '') {
       // eslint-disable-next-line no-console
       console.warn(
-        `ContentPanel "${panelType}": ${unsupportedProps} not supported with the collapsibleGroup option and will be ignored.`,
+        `ContentPanel "${panelType}": the following props are not supported when collapsibleGroup is enabled and will be ignored: ${unsupportedProps}.`,
       )
     }
   }, [unsupportedProps, panelType])

--- a/src/components/ContentPanel/ContentPanel.tsx
+++ b/src/components/ContentPanel/ContentPanel.tsx
@@ -1,12 +1,16 @@
 import '@jetbrains/ring-ui-built/components/style.css'
 import ChevronDownIcon from '@jetbrains/icons/chevron-down.js'
 import ChevronRightIcon from '@jetbrains/icons/chevron-right.js'
+import FileIcon from '@jetbrains/icons/file.js'
+import Avatar, {Size} from '@jetbrains/ring-ui-built/components/avatar/avatar.js'
+import CollapsibleGroup from '@jetbrains/ring-ui-built/components/collapsible-group/collapsible-group.js'
 import {H2} from '@jetbrains/ring-ui-built/components/heading/heading.js'
+import type {IconType} from '@jetbrains/ring-ui-built/components/icon/icon'
 import LoaderInline from '@jetbrains/ring-ui-built/components/loader-inline/loader-inline.js'
 import classNames from 'classnames'
 import * as React from 'react'
 import type {HTMLAttributes} from 'react'
-import {Suspense, useContext, useLayoutEffect} from 'react'
+import {Suspense, useContext, useEffect, useLayoutEffect} from 'react'
 
 import SvgIcon from '../SvgIcon/SvgIcon'
 
@@ -48,29 +52,66 @@ export type ContentPanelProps = {
     HTMLAttributes<HTMLHeadingElement>,
     'children' | 'dangerouslySetInnerHTML'
   >
+  /**
+   * Render the panel using Ring UI's `CollapsibleGroup` (off by default).
+   *
+   * Two behaviours differ from the default mode, by design:
+   * - The header is a disclosure button, not an `<h2>` heading — Ring renders the title inside
+   *   the toggle button, where a heading element would be invalid markup. `headingProps` is
+   *   therefore ignored in this mode.
+   * - `content` is unmounted while collapsed (the default mode keeps it mounted and toggles
+   *   `display: none`), so any local state, subscriptions, or cached data inside `content`
+   *   reset on every collapse/expand. Lift such state above `ContentPanel` if it must survive.
+   */
+  readonly collapsibleGroup?: boolean
+  readonly icon?: IconType | string
 }
 
-function ContentPanel({
-  className,
-  headingClassName,
-  subheadingClassName,
-  contentClassName,
-  panelType,
-  heading,
-  subheading,
-  headerSnippet,
-  content,
-  expandable = true,
-  withBorder = true,
-  expandedByDefault = true,
-  errorHeading,
-  headingProps,
-  ...restProps
-}: ContentPanelProps) {
+const PROPS_UNSUPPORTED_WITH_COLLAPSIBLE_GROUP = [
+  'headerSnippet',
+  'withBorder',
+  'headingClassName',
+  'subheadingClassName',
+  'contentClassName',
+  'headingProps',
+] as const satisfies readonly (keyof ContentPanelProps)[]
+
+function ContentPanel(props: ContentPanelProps) {
+  const {
+    className,
+    headingClassName,
+    subheadingClassName,
+    contentClassName,
+    panelType,
+    heading,
+    subheading,
+    headerSnippet,
+    content,
+    expandable = true,
+    withBorder = true,
+    expandedByDefault = true,
+    errorHeading,
+    headingProps,
+    collapsibleGroup = false,
+    icon = FileIcon,
+    ...restProps
+  } = props
   const {expanded, setExpanded, setParams} = useContext(ContentPanelContext)
   useLayoutEffect(() => {
     setParams({panelType, expandedByDefault})
   }, [expandedByDefault, panelType, setParams])
+
+  const unsupportedProps = collapsibleGroup
+    ? PROPS_UNSUPPORTED_WITH_COLLAPSIBLE_GROUP.filter(name => props[name] !== undefined).join(', ')
+    : ''
+  useEffect(() => {
+    if (unsupportedProps !== '') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `ContentPanel "${panelType}": ${unsupportedProps} not supported with the collapsibleGroup option and will be ignored.`,
+      )
+    }
+  }, [unsupportedProps, panelType])
   const HeadingHtml = React.useMemo(
     () => (
       <HTMLHeading {...headingProps}>
@@ -113,6 +154,56 @@ function ContentPanel({
       headingProps,
     ],
   )
+
+  if (collapsibleGroup) {
+    const error = errorHeading === true
+    // Title is inline text, not <HTMLHeading>: CollapsibleGroup renders it inside the toggle
+    // <button>, where a heading element is invalid markup. See the prop's JSDoc for details.
+    return (
+      <CollapsibleGroup
+        className={className}
+        data-test={panelType}
+        avatar={
+          <Avatar
+            round
+            size={Size.Size28}
+            className={error ? styles.errorAvatar : undefined}
+            info={<SvgIcon className={error ? styles.errorHeading : undefined} icon={icon} />}
+          />
+        }
+        title={
+          <span
+            className={error ? styles.errorHeading : undefined}
+            data-test-panel-heading={panelType}
+          >
+            {heading}
+          </span>
+        }
+        subtitle={
+          subheading != null ? (
+            <span data-test-panel-subheading={panelType}>{subheading}</span>
+          ) : undefined
+        }
+        interactive={expandable}
+        expanded={expanded}
+        defaultExpanded={expandedByDefault}
+        onChange={setExpanded}
+      >
+        <div data-test-panel-content={panelType}>
+          <Suspense
+            fallback={
+              <span>
+                <LoaderInline>{'Loading...'}</LoaderInline>
+              </span>
+            }
+          >
+            {content}
+          </Suspense>
+        </div>
+      </CollapsibleGroup>
+    )
+  }
+
   return (
     <div
       className={classNames(className, styles.wrapper, {


### PR DESCRIPTION
Implements the build/job overview redesign foundation for [TW-96574](https://youtrack.jetbrains.com/issue/TW-96574): an opt-in `CollapsibleGroup` rendering mode for `ContentPanel`.

## What

- New `ContentPanel` props (both inert in the existing/default mode):
  - `collapsibleGroup` (boolean, default `false`) — render via Ring UI's `CollapsibleGroup`.
  - `icon` (`IconType | string`, default `@jetbrains/icons/file`) — shown in a round 28px Ring UI `Avatar` (gray circle + secondary-colored icon by default).
- `errorHeading` in this mode reddens the title, icon, and avatar background (matches the Figma error state).
- Warns via `console.warn` when a prop the mode ignores is passed (`headerSnippet`, `withBorder`, `headingClassName`, `subheadingClassName`, `contentClassName`, `headingProps`).
- Bumps `@jetbrains/ring-ui` / `@jetbrains/ring-ui-built` to **7.0.116** (where `CollapsibleGroup` now lives).
- Adds `ContentPanel` Storybook stories and applies Ring UI's default font to all stories via the Storybook preview.

**Default rendering is unchanged.**

## Behaviour differences in `collapsibleGroup` mode (documented on the prop)

- The header is a disclosure **button**, not an `<h2>` — Ring renders the title inside the toggle button, where a heading element would be invalid markup, so `headingProps` does not apply.
- `content` is **unmounted while collapsed** (the default mode keeps it mounted via `display: none`), so local state / subscriptions / cached data inside it reset on each collapse/expand.

## Verification

`npm run typecheck`, `npm run lint`, `npm run build`, and `npm test` all pass. Stories: `Default`, `AsCollapsibleGroup`, `AsCollapsibleGroupError`, `CollapsedByDefault`, `CollapsibleGroupWithIgnoredProps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
